### PR TITLE
wrong tmp_path alloc size, not uniq temp file

### DIFF
--- a/cpp-libawd/src/util.cc
+++ b/cpp-libawd/src/util.cc
@@ -177,7 +177,7 @@ awdutil_mktmp(char **path)
     else fd = -1;
 
 #else
-    tpl_len = strlen(TMPFILE_TEMPLATE);
+    tpl_len = strlen(TMPFILE_TEMPLATE) + 1;
     tmp_path = (char *)malloc(tpl_len);
     strncpy_s(tmp_path, tpl_len, TMPFILE_TEMPLATE, tpl_len);
 


### PR DESCRIPTION
Hi,

It's a small fix for non windows platforms.
The creation of temp file (`awdutil_mktmp`) is broken on OSX. `tmp_path` isn't null terminated, then `mkstemp` don't work properly.

Pierre
